### PR TITLE
CI update

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -57,9 +57,11 @@ EOF
 
 ## Compatibility
 
-| Version | Status     | Python compatibility | HAproxy compatibility |
-| ------- | ---------- | -------------------- | --------------------- |
-| 1.x     | maintained | >=2.7                | >=1.8                 |
+| Version | Status                  | Python compatibility | HAproxy compatibility |
+| ------- | ----------------------- | -------------------- | --------------------- |
+| 1.x     | maintained but untested | cpython >=2.7        | >=1.8                 |
+| 1.x     | maintained and tested   | cpython >=3.7        | >=1.8                 |
+| 1.x     | maintained and tested   | pypy >=3.7           | >=1.8                 |
 
 ## Requirements
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,22 @@
+name: commit-lint
+
+on: [pull_request]
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event.pull_request.commits }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Commits linter
+        uses: bugbundle/commits@v1.1.0
+        id: commits
+
+      - name: Preview the version
+        run: echo ${{ steps.commits.outputs.major }}.${{ steps.commits.outputs.minor }}.${{ steps.commits.outputs.patch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,34 +9,6 @@ on:
       - master
 
 jobs:
-  test-py2:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Setup Python environment
-        uses: actions/setup-python@v5
-        with:
-          python-version: 2.7
-          architecture: x64
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install mock pycodestyle pytest
-          echo "PYTHONPATH=/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages" >> $GITHUB_ENV
-          sudo ln -sf $(which python) /usr/bin/python2
-
-      - name: Run tests
-        run: |
-          py.test haproxy_test.py
-
-      - name: Run codestyle check
-        run: |
-          pycodestyle *.py
-
   test-py3:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,11 @@ on:
       - master
 
 jobs:
-  test-py3:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.7', 'pypy3.8', 'pypy3.9', 'pypy3.10']
 
     steps:
       - name: Checkout repository
@@ -19,19 +22,24 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
-          architecture: x64
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install mock pycodestyle pytest
-          echo "PYTHONPATH=/opt/hostedtoolcache/Python/3.7.6/x64/lib/python3.7/site-packages" >> $GITHUB_ENV
-          sudo ln -sf $(which python) /usr/bin/python3
+          pip install -r requirements.txt
 
       - name: Run tests
-        run: |
-          py.test haproxy_test.py
+        run: pytest haproxy_test.py --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.python-version }}.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
 
       - name: Run codestyle check
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Python environment
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 2.7
           architecture: x64
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Python environment
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
           architecture: x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python environment
         uses: actions/setup-python@v5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mock
+pycodestyle
+pytest
+pytest-cov


### PR DESCRIPTION
### Improvement

<!-- Fill in the relevant information below to help triage your issue. -->

|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | yes
| BC Break    | no
| Issue       | -

#### Summary

This MR introduces support for updated versions of GitHub workflows.

Simultaneously, it removes testing for Python 2 from the CI and introduces testing for CPython >= 3.7 and PyPy >= 3.7. 
